### PR TITLE
accepted patch by abradley2

### DIFF
--- a/day01/elm/RobertWalter83/src/Main.elm
+++ b/day01/elm/RobertWalter83/src/Main.elm
@@ -23,11 +23,8 @@ init =
 
 findDup : Int -> List Int -> Set Int -> Maybe Int
 findDup frqCurrent rgDelta memory = 
-  let
-    mbDeltaNext = List.head rgDelta
-  in
-    case mbDeltaNext of
-      Just deltaNext ->
+  Maybe.andThen
+    (\deltaNext ->
         let 
           frqNext = frqCurrent + deltaNext
           isDuplicate = Set.member frqNext memory
@@ -40,9 +37,8 @@ findDup frqCurrent rgDelta memory =
               rgDataNew = List.append (List.drop 1 rgDelta) [deltaNext]  
             in
               findDup frqNext rgDataNew memoryNew
-
-      Maybe.Nothing ->
-        Maybe.Nothing
+    )
+    (List.head rgDelta)
 
 -- UPDATE
 


### PR DESCRIPTION
Here's a possible way you can clean up a small section of code.

Generally whenever you see yourself doing something like

```
  case Nothing ->
    Nothing
```

What you really want is `Maybe.map` and `Maybe.andThen` to  work on the `Just` result of a maybe but not care about the `Nothing` branch